### PR TITLE
chore: scaffold author site with sample content

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["next/core-web-vitals", "eslint:recommended"],
+  "plugins": [],
+  "rules": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env
+.DS_Store
+.contentlayer

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# Personal-Website
+# Author Website
+
+This is a minimal starter for an author website built with Next.js 14, TypeScript and MDX. It includes sample content for articles, newsletter notes and podcast episodes.
+
+## Getting Started
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Run the development server
+
+```bash
+npm run dev
+```
+
+The site uses Contentlayer for MDX content located in the `content/` directory.
+
+## Content
+
+- `content/posts` – blog posts
+- `content/notes` – newsletter notes
+- `content/episodes` – podcast notes
+
+## Tests
+
+Simple unit tests are located in `tests/` and can be run with:
+
+```bash
+npm test
+```
+
+## Deployment
+
+Deploy to Vercel or any platform supporting Next.js 14.
+
+## Environment Variables
+
+- `NEXT_PUBLIC_SITE_URL` – canonical site URL used in sitemap and RSS.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">About</h1>
+      <p>This is a short bio about the author, mission, and press highlights.</p>
+    </div>
+  );
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const { email } = await request.json();
+  console.log('Received email', email);
+  return NextResponse.json({ ok: true });
+}

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation';
+import { allPosts } from 'contentlayer/generated';
+import { useMDXComponent } from 'next-contentlayer/hooks';
+
+interface Props { params: { slug: string } }
+
+export default function ArticlePage({ params }: Props) {
+  const post = allPosts.find((p) => p.slug === params.slug);
+  if (!post) return notFound();
+  const MDXContent = useMDXComponent(post.body.code);
+  return (
+    <article className="prose dark:prose-invert">
+      <h1>{post.title}</h1>
+      <p className="text-sm text-gray-500">{post.date}</p>
+      <MDXContent />
+    </article>
+  );
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { allPosts } from 'contentlayer/generated';
+
+export default function ArticlesPage() {
+  const posts = allPosts.sort((a, b) => (a.date > b.date ? -1 : 1));
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-4">Articles</h1>
+      <ul className="space-y-2">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link href={post.url} className="underline">
+              {post.title}
+            </Link>
+            <span className="ml-2 text-sm text-gray-500">{post.date}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+import { books } from '@/lib/books';
+
+export default function BooksPage() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-4">Books</h1>
+      <div className="grid gap-6 sm:grid-cols-2">
+        {books.map((book) => (
+          <div key={book.slug} className="border p-4">
+            <Image src={book.cover} alt="" width={300} height={450} />
+            <h2 className="text-xl font-semibold mt-2">{book.title}</h2>
+            <p className="mt-1">{book.blurb}</p>
+            <a href={book.buyUrl} className="underline mt-2 inline-block">
+              Buy
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,8 @@
+export default function CommunityPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Community</h1>
+      <p>Premium content coming soon. For now, join the free newsletter to stay informed.</p>
+    </div>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Contact</h1>
+      <p>Email us at <a href="mailto:hello@example.com" className="underline">hello@example.com</a>.</p>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white text-black dark:bg-gray-950 dark:text-gray-100;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,32 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import { ThemeProvider } from 'next-themes';
+import Script from 'next/script';
+import SiteHeader from '@/components/site-header';
+import SiteFooter from '@/components/site-footer';
+
+export const metadata = {
+  title: 'Author Site',
+  description: 'Personal website for writing and podcasts',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        {process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN && (
+          <Script
+            defer
+            data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
+            src="https://plausible.io/js/script.js"
+          />
+        )}
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <SiteHeader />
+          <main className="min-h-screen p-4">{children}</main>
+          <SiteFooter />
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/newsletter/[slug]/page.tsx
+++ b/app/newsletter/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation';
+import { allNotes } from 'contentlayer/generated';
+import { useMDXComponent } from 'next-contentlayer/hooks';
+
+interface Props { params: { slug: string } }
+
+export default function NotePage({ params }: Props) {
+  const note = allNotes.find((n) => n.slug === params.slug);
+  if (!note) return notFound();
+  const MDXContent = useMDXComponent(note.body.code);
+  return (
+    <article className="prose dark:prose-invert">
+      <h1>{note.title}</h1>
+      <p className="text-sm text-gray-500">{note.date}</p>
+      <MDXContent />
+    </article>
+  );
+}

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { allNotes } from 'contentlayer/generated';
+import NewsletterForm from '@/components/newsletter-form';
+
+export default function NewsletterPage() {
+  const notes = allNotes.sort((a, b) => (a.date > b.date ? -1 : 1)).slice(0, 10);
+  return (
+    <div className="space-y-6">
+      <section>
+        <h1 className="text-3xl font-bold">Newsletter</h1>
+        <p className="mt-2">Short notes and prompts every few weeks.</p>
+        <div className="mt-4">
+          <NewsletterForm />
+        </div>
+      </section>
+      <section>
+        <h2 className="text-2xl font-semibold">Recent Notes</h2>
+        <ul className="space-y-2">
+          {notes.map((note) => (
+            <li key={note.slug}>
+              <Link href={note.url} className="underline">
+                {note.title}
+              </Link>
+              <span className="ml-2 text-sm text-gray-500">{note.date}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/opengraph-image/route.ts
+++ b/app/opengraph-image/route.ts
@@ -1,0 +1,27 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get('title') || 'Author Site';
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'white',
+          color: 'black',
+          fontSize: 48,
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {title}
+      </div>
+    )
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { allPosts, allNotes, allEpisodes } from 'contentlayer/generated';
+
+export default function HomePage() {
+  const latestPosts = allPosts.slice(0, 3);
+  const latestEpisodes = allEpisodes.slice(0, 3);
+  return (
+    <div className="space-y-8">
+      <section>
+        <h1 className="text-3xl font-bold">Welcome</h1>
+        <p className="mt-2">I write about living with intention.</p>
+        <div className="mt-4 flex gap-4">
+          <Link href="/articles" className="underline">Read Articles</Link>
+          <Link href="/newsletter" className="underline">Join Newsletter</Link>
+        </div>
+      </section>
+      <section>
+        <h2 className="text-2xl font-semibold">Latest Articles</h2>
+        <ul className="list-disc ml-6">
+          {latestPosts.map((post) => (
+            <li key={post.slug}>
+              <Link href={post.url}>{post.title}</Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-2xl font-semibold">From the Podcast</h2>
+        <ul className="list-disc ml-6">
+          {latestEpisodes.map((ep) => (
+            <li key={ep.slug}>
+              <Link href={ep.url}>{ep.title}</Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/podcast/[slug]/page.tsx
+++ b/app/podcast/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation';
+import { allEpisodes } from 'contentlayer/generated';
+import { useMDXComponent } from 'next-contentlayer/hooks';
+
+interface Props { params: { slug: string } }
+
+export default function EpisodePage({ params }: Props) {
+  const ep = allEpisodes.find((e) => e.slug === params.slug);
+  if (!ep) return notFound();
+  const MDXContent = useMDXComponent(ep.body.code);
+  return (
+    <article className="prose dark:prose-invert">
+      <h1>{ep.title}</h1>
+      <p className="text-sm text-gray-500">{ep.date} • {ep.duration}</p>
+      <audio controls src={ep.audioUrl} className="my-4" />
+      <MDXContent />
+    </article>
+  );
+}

--- a/app/podcast/page.tsx
+++ b/app/podcast/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { allEpisodes } from 'contentlayer/generated';
+
+export default function PodcastPage() {
+  const eps = allEpisodes.sort((a, b) => (a.date > b.date ? -1 : 1));
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-4">Podcast</h1>
+      <ul className="space-y-2">
+        {eps.map((ep) => (
+          <li key={ep.slug}>
+            <Link href={ep.url} className="underline">
+              {ep.title}
+            </Link>
+            <span className="ml-2 text-sm text-gray-500">{ep.date}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,8 @@
+export default function PrivacyPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p>We respect your privacy. This placeholder text outlines data practices.</p>
+    </div>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,8 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: '*', allow: '/' }],
+    sitemap: 'https://example.com/sitemap.xml',
+  };
+}

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { allPosts } from 'contentlayer/generated';
+import { generateRss } from '@/lib/rss';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  const rss = generateRss(allPosts, 'https://example.com');
+  return new NextResponse(rss, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}

--- a/app/rss/articles.xml/route.ts
+++ b/app/rss/articles.xml/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { allPosts } from 'contentlayer/generated';
+import { generateRss } from '@/lib/rss';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  const rss = generateRss(allPosts, 'https://example.com');
+  return new NextResponse(rss, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
+}

--- a/app/rss/podcast.xml/route.ts
+++ b/app/rss/podcast.xml/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { allEpisodes } from 'contentlayer/generated';
+import { generateEpisodeRss } from '@/lib/rss';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  const items = allEpisodes.map((e) => ({ title: e.title, url: e.url, date: e.date }));
+  const rss = generateEpisodeRss(items, 'https://example.com');
+  return new NextResponse(rss, { headers: { 'Content-Type': 'application/xml' } });
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,9 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: 'https://example.com/' },
+    { url: 'https://example.com/articles' },
+    { url: 'https://example.com/books' },
+  ];
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,8 @@
+export default function TermsPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Terms of Use</h1>
+      <p>Here we describe the terms for using this website.</p>
+    </div>
+  );
+}

--- a/components/newsletter-form.tsx
+++ b/components/newsletter-form.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const schema = z.object({ email: z.string().email() });
+
+type FormData = z.infer<typeof schema>;
+
+export default function NewsletterForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>();
+  const [submitted, setSubmitted] = useState(false);
+  const onSubmit = (data: FormData) => {
+    console.log('subscribe', data.email);
+    setSubmitted(true);
+  };
+  if (submitted) return <p>Thanks for subscribing!</p>;
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex gap-2">
+      <input type="email" placeholder="you@example.com" {...register('email')} className="border p-2" />
+      <button type="submit" className="border p-2">Join</button>
+      {errors.email && <span className="text-red-500 text-sm">Invalid email</span>}
+    </form>
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function SiteFooter() {
+  return (
+    <footer className="p-4 border-t text-sm text-center">
+      <div className="flex justify-center gap-4">
+        <Link href="/privacy">Privacy</Link>
+        <Link href="/terms">Terms</Link>
+        <Link href="/contact">Contact</Link>
+      </div>
+      <p className="mt-2">© {new Date().getFullYear()} Author.</p>
+    </footer>
+  );
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default function SiteHeader() {
+  return (
+    <header className="p-4 border-b">
+      <nav className="flex gap-4">
+        <Link href="/">Home</Link>
+        <Link href="/articles">Articles</Link>
+        <Link href="/books">Books</Link>
+        <Link href="/newsletter">Newsletter</Link>
+        <Link href="/podcast">Podcast</Link>
+        <Link href="/community">Community</Link>
+        <Link href="/about">About</Link>
+      </nav>
+    </header>
+  );
+}

--- a/content/episodes/episode-five.mdx
+++ b/content/episodes/episode-five.mdx
@@ -1,0 +1,10 @@
+---
+title: "Episode Five: The Small Win"
+slug: "the-small-win"
+date: "2024-05-21"
+audioUrl: "https://example.com/audio5.mp3"
+duration: "08:40"
+summary: "Celebrating progress even when it's modest."
+tags: ["motivation"]
+---
+Not every victory is loud. We chat about noticing and sharing the quiet ones.

--- a/content/episodes/episode-four.mdx
+++ b/content/episodes/episode-four.mdx
@@ -1,0 +1,10 @@
+---
+title: "Episode Four: Finding Flow"
+slug: "finding-flow"
+date: "2024-04-18"
+audioUrl: "https://example.com/audio4.mp3"
+duration: "11:05"
+summary: "Tactics for slipping into deep work."
+tags: ["focus"]
+---
+We discuss rituals that help you enter that timeless zone where work feels like play.

--- a/content/episodes/episode-one.mdx
+++ b/content/episodes/episode-one.mdx
@@ -1,0 +1,10 @@
+---
+title: "Episode One: Begin Anywhere"
+slug: "begin-anywhere"
+date: "2024-01-15"
+audioUrl: "https://example.com/audio1.mp3"
+duration: "12:34"
+summary: "Thoughts on starting before you're ready."
+tags: ["mindset"]
+---
+Welcome to the first episode. We explore how imperfect starts lead to momentum.

--- a/content/episodes/episode-three.mdx
+++ b/content/episodes/episode-three.mdx
@@ -1,0 +1,10 @@
+---
+title: "Episode Three: Kind Words"
+slug: "kind-words"
+date: "2024-03-22"
+audioUrl: "https://example.com/audio3.mp3"
+duration: "15:10"
+summary: "Exploring the ripple effect of encouragement."
+tags: ["relationships"]
+---
+A simple compliment can shift someone's day. We share stories and science behind verbal kindness.

--- a/content/episodes/episode-two.mdx
+++ b/content/episodes/episode-two.mdx
@@ -1,0 +1,10 @@
+---
+title: "Episode Two: The Pause"
+slug: "the-pause"
+date: "2024-02-12"
+audioUrl: "https://example.com/audio2.mp3"
+duration: "09:58"
+summary: "How stepping back can speed you up."
+tags: ["productivity"]
+---
+In this episode we talk about intentional breaks and why rest is a strategy.

--- a/content/notes/digital-sabbath.mdx
+++ b/content/notes/digital-sabbath.mdx
@@ -1,0 +1,8 @@
+---
+title: "Digital Sabbath"
+slug: "digital-sabbath"
+date: "2024-03-02"
+topic: "habit"
+cta: "Unplug for one hour this weekend."
+---
+Silence the screens and watch how the mind stretches when given space.

--- a/content/notes/gratitude-note.mdx
+++ b/content/notes/gratitude-note.mdx
@@ -1,0 +1,8 @@
+---
+title: "Gratitude Note"
+slug: "gratitude-note"
+date: "2024-04-18"
+topic: "gratitude"
+cta: "Write a thank you message to someone you rarely acknowledge."
+---
+A quick note of thanks can turn a forgettable day into a bright one for both of you.

--- a/content/notes/morning-breath.mdx
+++ b/content/notes/morning-breath.mdx
@@ -1,0 +1,8 @@
+---
+title: "Morning Breath"
+slug: "morning-breath"
+date: "2024-01-10"
+topic: "mindfulness"
+cta: "Pause for three deep breaths before emails."
+---
+Begin your day by noticing the very first inhale. That tiny awareness sets a tone of calm.

--- a/content/notes/one-yes.mdx
+++ b/content/notes/one-yes.mdx
@@ -1,0 +1,8 @@
+---
+title: "One Yes"
+slug: "one-yes"
+date: "2024-05-30"
+topic: "opportunity"
+cta: "Accept an invitation you'd usually decline."
+---
+Say yes to something small and see where it leads.

--- a/content/notes/tiny-courage.mdx
+++ b/content/notes/tiny-courage.mdx
@@ -1,0 +1,8 @@
+---
+title: "Tiny Courage"
+slug: "tiny-courage"
+date: "2024-02-05"
+topic: "bravery"
+cta: "Say one honest thing today."
+---
+Courage rarely arrives as a roar. More often it's a whisper that nudges you to speak.

--- a/content/posts/finding-focus.mdx
+++ b/content/posts/finding-focus.mdx
@@ -1,0 +1,22 @@
+---
+title: "Finding Focus in a Distracted World"
+slug: "finding-focus"
+excerpt: "Simple ways to reclaim your attention."
+date: "2024-01-05"
+tags: ["productivity"]
+featured: true
+---
+
+Our days are filled with pings and pop-ups. This short piece shares three mindful habits for a calmer mind.
+
+## Pause on Purpose
+
+Take one minute each hour to breathe and reset. That minute often saves an hour.
+
+## Turn Down the Noise
+
+Mute non-essential alerts. The world rarely ends when your phone is quiet.
+
+## Guard the Mornings
+
+Start the day with your most meaningful task before checking messages.

--- a/content/posts/love-in-practice.mdx
+++ b/content/posts/love-in-practice.mdx
@@ -1,0 +1,21 @@
+---
+title: "Love in Practice"
+slug: "love-in-practice"
+excerpt: "Small gestures that keep relationships strong."
+date: "2024-02-14"
+tags: ["relationships"]
+---
+
+Relationships grow through action, not declarations. Here are a few everyday moves that matter.
+
+### Listen Fully
+
+Put away devices when someone shares their day. Presence is the rarest gift.
+
+### Share the Load
+
+Doing dishes together builds more than a clean sink.
+
+### Say the Little Thanks
+
+Noticing the ordinary efforts keeps goodwill alive.

--- a/content/posts/the-joy-meter.mdx
+++ b/content/posts/the-joy-meter.mdx
@@ -1,0 +1,13 @@
+---
+title: "The Joy Meter"
+slug: "the-joy-meter"
+excerpt: "Measuring delight in small daily moments."
+date: "2024-04-10"
+tags: ["happiness"]
+---
+
+Happiness hides in plain sight. Build a habit of marking tiny sparks of delight through the day.
+
+- The smell of coffee counts.
+- A brief chat with a neighbor counts.
+- Finishing this paragraph counts.

--- a/content/posts/tiny-steps.mdx
+++ b/content/posts/tiny-steps.mdx
@@ -1,0 +1,11 @@
+---
+title: "Tiny Steps, Big Changes"
+slug: "tiny-steps"
+excerpt: "Why small habits compound into transformation."
+date: "2024-05-15"
+tags: ["habits"]
+---
+
+Massive overhauls rarely stick. Stack modest actions instead and watch them multiply.
+
+> A five-minute walk today can become a marathon next year.

--- a/content/posts/why-we-ask.mdx
+++ b/content/posts/why-we-ask.mdx
@@ -1,0 +1,13 @@
+---
+title: "Why We Ask Why"
+slug: "why-we-ask"
+excerpt: "Curiosity as a compass for a meaningful life."
+date: "2024-03-20"
+tags: ["purpose"]
+---
+
+The question "why" can annoy parents and teachers, yet it fuels discovery. Use it to steer your days.
+
+1. **Start with Wonder** – let questions, not answers, guide your plans.
+2. **Embrace not knowing** – uncertainty is the birthplace of insight.
+3. **Follow the thread** – each answer opens another door; keep walking.

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,0 +1,64 @@
+import { defineDocumentType, makeSource } from 'contentlayer/source-files';
+
+export const Post = defineDocumentType(() => ({
+  name: 'Post',
+  filePathPattern: `posts/*.mdx`,
+  contentType: 'mdx',
+  fields: {
+    title: { type: 'string', required: true },
+    slug: { type: 'string', required: true },
+    excerpt: { type: 'string', required: true },
+    date: { type: 'date', required: true },
+    updated: { type: 'date', required: false },
+    tags: { type: 'list', of: { type: 'string' } },
+    coverImage: { type: 'string' },
+    canonicalUrl: { type: 'string' },
+    draft: { type: 'boolean', default: false },
+    featured: { type: 'boolean', default: false },
+  },
+  computedFields: {
+    url: {
+      type: 'string',
+      resolve: (doc) => `/articles/${doc.slug}`,
+    },
+  },
+}));
+
+export const Note = defineDocumentType(() => ({
+  name: 'Note',
+  filePathPattern: `notes/*.mdx`,
+  contentType: 'mdx',
+  fields: {
+    title: { type: 'string', required: true },
+    slug: { type: 'string', required: true },
+    date: { type: 'date', required: true },
+    topic: { type: 'string', required: true },
+    cta: { type: 'string', required: false },
+  },
+  computedFields: {
+    url: { type: 'string', resolve: (doc) => `/newsletter/${doc.slug}` },
+  },
+}));
+
+export const Episode = defineDocumentType(() => ({
+  name: 'Episode',
+  filePathPattern: `episodes/*.mdx`,
+  contentType: 'mdx',
+  fields: {
+    title: { type: 'string', required: true },
+    slug: { type: 'string', required: true },
+    date: { type: 'date', required: true },
+    audioUrl: { type: 'string', required: true },
+    duration: { type: 'string', required: true },
+    summary: { type: 'string', required: true },
+    tags: { type: 'list', of: { type: 'string' } },
+  },
+  computedFields: {
+    url: { type: 'string', resolve: (doc) => `/podcast/${doc.slug}` },
+  },
+}));
+
+export default makeSource({
+  contentDirPath: 'content',
+  documentTypes: [Post, Note, Episode],
+});

--- a/lib/books.ts
+++ b/lib/books.ts
@@ -1,0 +1,24 @@
+export interface Book {
+  title: string;
+  slug: string;
+  cover: string;
+  blurb: string;
+  buyUrl: string;
+}
+
+export const books: Book[] = [
+  {
+    title: 'Book One',
+    slug: 'book-one',
+    cover: '/book-one.svg',
+    blurb: 'A placeholder book about starting small.',
+    buyUrl: '#',
+  },
+  {
+    title: 'Book Two',
+    slug: 'book-two',
+    cover: '/book-two.svg',
+    blurb: 'Another placeholder book focusing on habits.',
+    buyUrl: '#',
+  },
+];

--- a/lib/reading-time.js
+++ b/lib/reading-time.js
@@ -1,0 +1,10 @@
+/**
+ * Estimate reading time for a block of text.
+ * @param {string} text
+ * @param {number} [wordsPerMinute=200]
+ * @returns {number} minutes
+ */
+export function readingTime(text, wordsPerMinute = 200) {
+  const words = text.trim().split(/\s+/).length;
+  return Math.ceil(words / wordsPerMinute);
+}

--- a/lib/rss.js
+++ b/lib/rss.js
@@ -1,0 +1,29 @@
+/**
+ * Build a minimal RSS feed for posts.
+ * @param {{title:string,url:string,date:string}[]} posts
+ * @param {string} baseUrl
+ */
+export function generateRss(posts, baseUrl) {
+  const items = posts
+    .map(
+      (p) =>
+        `\n    <item>\n      <title>${p.title}</title>\n      <link>${baseUrl}${p.url}</link>\n      <pubDate>${p.date}</pubDate>\n    </item>`
+    )
+    .join('');
+  return `<?xml version="1.0"?><rss version="2.0"><channel><title>RSS</title>${items}\n  </channel></rss>`;
+}
+
+/**
+ * Build RSS for podcast episodes.
+ * @param {{title:string,url:string,date:string}[]} items
+ * @param {string} baseUrl
+ */
+export function generateEpisodeRss(items, baseUrl) {
+  const xml = items
+    .map(
+      (i) =>
+        `\n    <item>\n      <title>${i.title}</title>\n      <link>${baseUrl}${i.url}</link>\n      <pubDate>${i.date}</pubDate>\n    </item>`
+    )
+    .join('');
+  return `<?xml version="1.0"?><rss version="2.0"><channel><title>Podcast</title>${xml}\n  </channel></rss>`;
+}

--- a/lib/slugify.js
+++ b/lib/slugify.js
@@ -1,0 +1,11 @@
+/**
+ * Convert a string into URL-friendly slug.
+ * @param {string} str
+ * @returns {string}
+ */
+export function slugify(str) {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://example.com',
+  generateRobotsTxt: true,
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,11 @@
+import { withContentlayer } from 'next-contentlayer';
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+};
+
+export default withContentlayer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "author-website",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "node tests/run-tests.js"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-themes": "0.2.1",
+    "contentlayer": "0.3.2",
+    "next-contentlayer": "0.3.2",
+    "minisearch": "6.1.0",
+    "zod": "3.23.8",
+    "react-hook-form": "7.48.2",
+    "lucide-react": "0.379.0",
+    "tailwindcss": "3.4.4",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.17",
+    "@tailwindcss/typography": "0.5.10"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.20",
+    "@types/node": "20.11.30",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.0",
+    "prettier": "3.2.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/book-one.svg
+++ b/public/book-one.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="450" viewBox="0 0 300 450">
+  <rect width="300" height="450" fill="#e5e5e5"/>
+  <text x="150" y="225" font-size="24" text-anchor="middle" fill="#333">Book One</text>
+</svg>

--- a/public/book-two.svg
+++ b/public/book-two.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="450" viewBox="0 0 300 450">
+  <rect width="300" height="450" fill="#d0d0d0"/>
+  <text x="150" y="225" font-size="24" text-anchor="middle" fill="#333">Book Two</text>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="8">
+  <circle cx="50" cy="50" r="40" />
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="currentColor">A</text>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx,mdx}', './app/**/*.{ts,tsx,mdx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('@tailwindcss/typography')],
+};
+export default config;

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { readingTime } from '../lib/reading-time.js';
+import { slugify } from '../lib/slugify.js';
+import { generateRss } from '../lib/rss.js';
+
+function testReadingTime() {
+  const text = 'one two three four five';
+  assert.strictEqual(readingTime(text, 200), 1);
+}
+
+function testSlugify() {
+  assert.strictEqual(slugify('Hello World!'), 'hello-world');
+}
+
+function testRss() {
+  const posts = [{ title: 'Test', url: '/test', date: '2024-01-01' }];
+  const rss = generateRss(posts, 'https://example.com');
+  assert.ok(rss.includes('<title>Test</title>'));
+}
+
+testReadingTime();
+testSlugify();
+testRss();
+
+console.log('All tests passed');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["contentlayer/generated"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".contentlayer/generated"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with Tailwind, Contentlayer, and sample pages
- add MDX content for posts, notes, and podcast episodes
- include basic utilities, RSS feed generator, and tests

## Testing
- `node tests/run-tests.js`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d482119c832ca20e0aec4ae9a961