### PR TITLE
refactor: use absolute imports in blueprint routes

### DIFF
--- a/flask_mark_style/app/blueprints/account/routes.py
+++ b/flask_mark_style/app/blueprints/account/routes.py
@@ -1,9 +1,9 @@
 from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_user, logout_user, login_required, current_user
 from . import bp
-from ..forms import LoginForm, RegisterForm
-from ..models import User
-from ..extensions import db
+from app.forms import LoginForm, RegisterForm
+from app.models import User
+from app.extensions import db
 
 
 @bp.route('/login', methods=['GET', 'POST'])

--- a/flask_mark_style/app/blueprints/articles/routes.py
+++ b/flask_mark_style/app/blueprints/articles/routes.py
@@ -1,6 +1,6 @@
 from flask import render_template, request
 from . import bp
-from ..models import Article
+from app.models import Article
 
 @bp.route('/')
 def index():

--- a/flask_mark_style/app/blueprints/books/routes.py
+++ b/flask_mark_style/app/blueprints/books/routes.py
@@ -1,6 +1,6 @@
 from flask import render_template
 from . import bp
-from ..models import Book
+from app.models import Book
 
 
 @bp.route('/')

--- a/flask_mark_style/app/blueprints/courses/routes.py
+++ b/flask_mark_style/app/blueprints/courses/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template
 from flask_login import login_required, current_user
 from . import bp
-from ..models import Course, Lesson
+from app.models import Course, Lesson
 
 
 @bp.route('/')

--- a/flask_mark_style/app/blueprints/main/routes.py
+++ b/flask_mark_style/app/blueprints/main/routes.py
@@ -1,9 +1,9 @@
 from flask import render_template, redirect, url_for, flash
 from . import bp
-from ..forms import ContactForm
-from ..emails import email_adapter
-from ..extensions import db
-from ..models import ContactMessage
+from app.forms import ContactForm
+from app.emails import email_adapter
+from app.extensions import db
+from app.models import ContactMessage
 
 
 @bp.route('/')

--- a/flask_mark_style/app/blueprints/newsletter/routes.py
+++ b/flask_mark_style/app/blueprints/newsletter/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, redirect, url_for, flash
 from . import bp
-from ..models import NewsletterIssue
-from ..emails import email_adapter
+from app.models import NewsletterIssue
+from app.emails import email_adapter
 
 
 @bp.route('/')


### PR DESCRIPTION
## Summary
- replace relative imports with absolute `app` imports in all Flask blueprint route modules

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=3.0)*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e655008832c8e308a793c4429b2