### PR TITLE
Fix Flask template/static folder configuration

### DIFF
--- a/flask_mark_style/app/__init__.py
+++ b/flask_mark_style/app/__init__.py
@@ -11,7 +11,12 @@ from .blueprints.admin import bp as admin_bp
 
 
 def create_app(config_class=DevConfig):
-    app = Flask(__name__, instance_relative_config=True)
+    app = Flask(
+        __name__,
+        instance_relative_config=True,
+        template_folder="../templates",
+        static_folder="../static",
+    )
     app.config.from_object(config_class)
 
     db.init_app(app)


### PR DESCRIPTION
## Summary
- ensure Flask app can locate templates and static files by setting explicit directories

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f536328832cb4a7725cfeb43e12