### PR TITLE
Enhance homepage with basic design and content

### DIFF
--- a/flask_mark_style/static/css/app.css
+++ b/flask_mark_style/static/css/app.css
@@ -1,1 +1,118 @@
 /* App CSS */
+
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  background-color: #f9fafb;
+  color: #1f2937;
+}
+
+nav {
+  background-color: #1f2937;
+  padding: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+main {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+footer {
+  background-color: #1f2937;
+  color: #9ca3af;
+  text-align: center;
+  padding: 1rem;
+  margin-top: 2rem;
+}
+
+footer a {
+  color: #9ca3af;
+  margin: 0 0.5rem;
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.tagline {
+  font-size: 1.25rem;
+  color: #4b5563;
+}
+
+.newsletter-section {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.newsletter-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.newsletter-form input {
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  width: 100%;
+  max-width: 300px;
+}
+
+.newsletter-form button {
+  background-color: #2563eb;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.newsletter-form button:hover {
+  background-color: #1e3a8a;
+}
+
+.privacy-note {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.about-preview {
+  margin-top: 2rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/flask_mark_style/templates/_base.html
+++ b/flask_mark_style/templates/_base.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Site{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>

--- a/flask_mark_style/templates/_partials/newsletter_cta.html
+++ b/flask_mark_style/templates/_partials/newsletter_cta.html
@@ -1,6 +1,6 @@
-<section>
-  <form action="/breakthrough/subscribe" method="post">
-    <label>Email <input type="email" name="email"></label>
-    <button type="submit">Subscribe</button>
-  </form>
-</section>
+<form action="/breakthrough/subscribe" method="post" class="newsletter-form">
+  <label for="email" class="sr-only">Email address</label>
+  <input id="email" type="email" name="email" placeholder="you@example.com" required>
+  <button type="submit">Subscribe</button>
+  <p class="privacy-note">No spam. Unsubscribe any time.</p>
+</form>

--- a/flask_mark_style/templates/main/home.html
+++ b/flask_mark_style/templates/main/home.html
@@ -1,6 +1,18 @@
 {% extends '_base.html' %}
 {% block title %}Home{% endblock %}
 {% block content %}
-<h1>Welcome</h1>
-{% include '_partials/newsletter_cta.html' %}
+<section class="hero">
+  <h1>Welcome to My Site</h1>
+  <p class="tagline">Insights on creativity, productivity, and living well.</p>
+</section>
+
+<section class="newsletter-section">
+  <h2>Join the Newsletter</h2>
+  {% include '_partials/newsletter_cta.html' %}
+</section>
+
+<section class="about-preview">
+  <h2>About</h2>
+  <p>I'm an author and creator sharing lessons on intentional living and the messy work of being human. Explore articles, books, and courses to help you grow.</p>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add responsive meta tag and link styling in base template
- style site elements with CSS and improve newsletter form
- populate home page with hero, newsletter signup, and about section

## Testing
- `PYTHONPATH=. pytest` *(fails: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc32595250832c9233a46a8fdcedca